### PR TITLE
deps: replace shortid with nanoid

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -28,7 +28,7 @@ const _extend = util._extend;
 const utils = require('./utils');
 const fieldsToArray = utils.fieldsToArray;
 const uuid = require('uuid');
-const shortid = require('shortid');
+const {nanoid} = require('nanoid');
 
 // Set up an object for quick lookup
 const BASE_TYPES = {
@@ -322,7 +322,8 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
           propVal = new Date();
           break;
         case 'shortid':
-          propVal = shortid.generate();
+        case 'nanoid':
+          propVal = nanoid(9);
           break;
         default:
           // TODO Support user-provided functions via a registry of functions

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "lodash": "^4.17.11",
     "loopback-connector": "^5.0.0",
     "minimatch": "^3.0.3",
+    "nanoid": "^3.1.20",
     "qs": "^6.5.0",
-    "shortid": "^2.2.6",
     "strong-globalize": "^6.0.5",
     "traverse": "^0.6.6",
     "uuid": "^8.3.1"

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -2182,6 +2182,27 @@ describe('manipulation', function() {
       });
     });
 
+    describe('nanoid defaultFn', function() {
+      let ModelWithNanoId;
+      before(createModelWithNanoId);
+
+      it('should generate a new id when "defaultFn" is "nanoid"', function(done) {
+        const NANOID_REGEXP = /^[0-9a-z_\-]{7,14}$/i;
+        ModelWithNanoId.create(function(err, modelWithNanoId) {
+          if (err) return done(err);
+          modelWithNanoId.nanoid.should.match(NANOID_REGEXP);
+          done();
+        });
+      });
+
+      function createModelWithNanoId(cb) {
+        ModelWithNanoId = db.define('ModelWithNanoId', {
+          nanoid: {type: String, defaultFn: 'nanoid'},
+        });
+        db.automigrate('ModelWithNanoId', cb);
+      }
+    });
+
     describe('shortid defaultFn', function() {
       let ModelWithShortId;
       before(createModelWithShortId);


### PR DESCRIPTION
Signed-off-by: Mario Estrada <marioestradarosa@yahoo.com>

shortid has been deprecated. The original repository suggests nanoid which in the tests proved to be much faster. The generation keeps the 9 chars length for compatibility. This is not a breaking change, since shortid and nanoid can be used as synonim for nanoid generation. 

Fixes issue reported at loopback-next repository : https://github.com/strongloop/loopback-next/issues/7584

## Checklist

- [x] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
