### PR TITLE
feat: add capability for insert multiple rows in single query

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -47,6 +47,8 @@ function Memory(m, settings) {
 
 util.inherits(Memory, Connector);
 
+Memory.prototype.multiInsertSupported = true;
+
 Memory.prototype.getDefaultIdType = function() {
   return Number;
 };
@@ -275,6 +277,29 @@ Memory.prototype.create = function create(model, data, options, callback) {
     }
     self.saveToFile(id, callback);
   });
+};
+
+Memory.prototype.createAll = function create(model, dataArray, options, callback) {
+  const returnArr = [];
+  async.eachSeries(
+    dataArray,
+    (data, cb) => {
+      this._createSync(model, data, (err, id) => {
+        if (err) {
+          return process.nextTick(function() {
+            cb(err);
+          });
+        }
+        const returnData = Object.assign({}, data);
+        this.setIdValue(model, returnData, id);
+        returnArr.push(returnData);
+        this.saveToFile(id, cb);
+      });
+    },
+    (err) => {
+      callback(err, returnArr);
+    },
+  );
 };
 
 Memory.prototype.updateOrCreate = function(model, data, options, callback) {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -457,6 +457,242 @@ DataAccessObject.create = function(data, options, cb) {
   return cb.promise;
 };
 
+/**
+ * Create an instances of Model with given data array and save to the attached data source. Callback is optional.
+ * Example:
+ *```js
+ * User.createAll([{first: 'Joe', last: 'Bob'},{first: 'Tom', last: 'Cat'}], function(err, users) {
+ *  console.log(users[0] instanceof User); // true
+ * });
+ * ```
+ * Note: You must include a callback and use the created models provided in the callback if your code depends on your model being
+ * saved or having an ID.
+ *
+ * @param {Object} [dataArray] Optional data object with array of records
+ * @param {Object} [options] Options for create
+ * @param {Function} [cb]  Callback function called with these arguments:
+ *   - err (null or Error)
+ *   - instance (null or Models)
+ */
+DataAccessObject.createAll = function(dataArray, options, cb) {
+  const connectionPromise = stillConnecting(this.getDataSource(), this, arguments);
+  if (connectionPromise) {
+    return connectionPromise;
+  }
+
+  let Model = this;
+  const connector = Model.getConnector();
+  if (!connector.multiInsertSupported) {
+    // If multi insert is not supported, then, revert to create method
+    // Array is handled in create method already in legacy code
+    // This ensures backwards compatibility
+    return this.create(dataArray, options, cb);
+  }
+  assert(
+    typeof connector.createAll === 'function',
+    'createAll() must be implemented by the connector',
+  );
+
+  if (options === undefined && cb === undefined) {
+    if (typeof dataArray === 'function') {
+      // create(cb)
+      cb = dataArray;
+      dataArray = [];
+    }
+  } else if (cb === undefined) {
+    if (typeof options === 'function') {
+      // create(data, cb);
+      cb = options;
+      options = {};
+    }
+  }
+
+  dataArray = dataArray || [];
+  options = options || {};
+  cb = cb || utils.createPromiseCallback();
+
+  assert(typeof dataArray === 'object' && dataArray.length,
+    'The data argument must be an array with length > 0');
+  assert(typeof options === 'object', 'The options argument must be an object');
+  assert(typeof cb === 'function', 'The cb argument must be a function');
+
+  const validationPromises = [];
+  for (let index = 0; index < dataArray.length; index++) {
+    const data = dataArray[index];
+    const hookState = {};
+
+    const enforced = {};
+    let obj;
+
+    try {
+      obj = new Model(data);
+
+      this.applyProperties(enforced, obj);
+      obj.setAttributes(enforced);
+    } catch (err) {
+      process.nextTick(function() {
+        cb(err);
+      });
+      return cb.promise;
+    }
+
+    Model = this.lookupModel(data); // data-specific
+    if (Model !== obj.constructor) obj = new Model(data);
+
+    const context = {
+      Model: Model,
+      instance: obj,
+      isNewInstance: true,
+      hookState: hookState,
+      options: options,
+    };
+
+    const promise = new Promise((resolve, reject) => {
+      Model.notifyObserversOf('before save', context, function(err) {
+        if (err) return reject({
+          error: err,
+          data: obj,
+        });
+
+        const d = obj.toObject(true);
+
+        // options has precedence on model-setting
+        if (options.validate === false) {
+          return resolve(obj);
+        }
+
+        // only when options.validate is not set, take model-setting into consideration
+        if (
+          options.validate === undefined &&
+        Model.settings.automaticValidation === false
+        ) {
+          return resolve(obj);
+        }
+
+        // validation required
+        obj.isValid(
+          function(valid) {
+            if (valid) {
+              resolve(obj);
+            } else {
+              reject({
+                error: new ValidationError(obj),
+                data: obj,
+              });
+            }
+          },
+          d,
+          options,
+        );
+      });
+    });
+    validationPromises.push(promise);
+  }
+
+  Promise.all(validationPromises).then((objArray) => {
+    const values = [];
+    const valMap = new Map();
+    objArray.forEach((obj) => {
+      const val = Model._sanitizeData(obj.toObject(true), options);
+      values.push(val);
+      valMap.set(obj, applyDefaultsOnWrites(val, Model.definition));
+    });
+
+    function createCallback(err, savedArray) {
+      if (err) {
+        return cb(err, objArray);
+      }
+
+      const context = values.map((val) => {
+        return {
+          Model: Model,
+          data: val,
+          isNewInstance: true,
+          hookState: {},
+          options: options,
+        };
+      });
+      Model.notifyObserversOf('loaded', context, function(err) {
+        if (err) return cb(err);
+
+        const afterSavePromises = [];
+        savedArray.map((obj) => {
+          const dataModel = new Model(obj);
+
+          let afterSavePromise;
+          if (options.notify !== false) {
+            const context = {
+              Model: Model,
+              instance: dataModel,
+              isNewInstance: true,
+              hookState: {},
+              options: options,
+            };
+
+            afterSavePromise = new Promise((resolve, reject) => {
+              Model.notifyObserversOf('after save', context, function(err) {
+                if (err) {
+                  reject(err);
+                } else {
+                  resolve(dataModel);
+                }
+              });
+            });
+            afterSavePromises.push(afterSavePromise);
+          } else {
+            afterSavePromises.push(Promise.resolve(dataModel));
+          }
+        });
+
+        Promise.all(afterSavePromises).then(saved => {
+          cb(null, saved);
+        }).catch(err => {
+          cb(err, objArray);
+        });
+      });
+    }
+
+    context = objArray.map(obj => {
+      return {
+        Model: Model,
+        data: valMap.get(obj),
+        isNewInstance: true,
+        currentInstance: obj,
+        hookState: {},
+        options: options,
+      };
+    });
+    const persistPromise = new Promise((resolve, reject) => {
+      Model.notifyObserversOf('persist', context, function(err, ctx) {
+        if (err) return reject(err);
+
+        const objDataArray = ctx
+          .map((obj) => {
+            return obj.currentInstance.constructor._forDB(obj.data);
+          })
+          .filter((objData) => !!objData);
+        resolve(objDataArray);
+      });
+    });
+    persistPromise.then((objDataArray) => {
+      invokeConnectorMethod(
+        connector,
+        'createAll',
+        Model,
+        [objDataArray],
+        options,
+        createCallback,
+      );
+    }).catch((err) => {
+      err && cb(err);
+    });
+  }).catch((err) => {
+    err && cb(err.error, err.data);
+  });
+
+  return cb.promise;
+};
+
 // Implementation of applyDefaultOnWrites property
 function applyDefaultsOnWrites(obj, modelDefinition) {
   for (const key in modelDefinition.properties) {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
     "lint": "eslint .",
     "build": "npm run build-ts-types",
     "build-ts-types": "tsc -p tsconfig.json --outDir dist",
+    "pretest": "npm run build",
     "test": "nyc mocha",
-    "posttest": "npm run tsc && npm run lint"
+    "posttest": "npm run lint"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",

--- a/test/crud-with-options.test.js
+++ b/test/crud-with-options.test.js
@@ -632,10 +632,13 @@ function seed(done) {
     {id: 5, seq: 5, name: 'Stuart Sutcliffe', order: 3, vip: true},
   ];
 
-  async.series([
-    User.destroyAll.bind(User),
-    function(cb) {
-      async.each(beatles, User.create.bind(User), cb);
-    },
-  ], done);
+  async.series(
+    [
+      User.destroyAll.bind(User),
+      function(cb) {
+        User.createAll(beatles, cb);
+      },
+    ],
+    done,
+  );
 }

--- a/test/helpers/context-test-helpers.js
+++ b/test/helpers/context-test-helpers.js
@@ -25,8 +25,16 @@ ContextRecorder.prototype.recordAndNext = function(transformFm) {
       transformFm(context);
     }
 
-    context = deepCloneToObject(context);
-    context.hookState.test = true;
+    if (Array.isArray(context)) {
+      context = context.map(ctx => {
+        const ctxCopy = deepCloneToObject(ctx);
+        ctxCopy.hookState.test = true;
+        return ctxCopy;
+      });
+    } else {
+      context = deepCloneToObject(context);
+      context.hookState.test = true;
+    }
 
     if (typeof self.records === 'string') {
       self.records = context;
@@ -37,7 +45,11 @@ ContextRecorder.prototype.recordAndNext = function(transformFm) {
       self.records = [self.records];
     }
 
-    self.records.push(context);
+    if (Array.isArray(context)) {
+      self.records.push(...context);
+    } else {
+      self.records.push(context);
+    }
     next();
   };
 };

--- a/types/persisted-model.d.ts
+++ b/types/persisted-model.d.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Callback, Options, PromiseOrVoid} from './common';
-import {ModelBase, ModelData} from './model';
-import {Filter, Where} from './query';
+import { Callback, Options, PromiseOrVoid } from './common';
+import { ModelBase, ModelData } from './model';
+import { Filter, Where } from './query';
 
 /**
  * Data object for persisted models
@@ -42,6 +42,21 @@ export declare class PersistedModel extends ModelBase {
   ): PromiseOrVoid<PersistedModel>;
 
   static create(
+    data: PersistedData[],
+    options?: Options,
+    callback?: Callback<PersistedModel[]>,
+  ): PromiseOrVoid<PersistedModel[]>;
+
+  /**
+   * Creates an array of new instances of Model, and save to database in one DB query.
+   *
+   * @param {Object[]} [data] Optional data argument. An array of instances.
+   *
+   * @callback {Function} callback Callback function called with `cb(err, obj)` signature.
+   * @param {Error} err Error object; see [Error object](http://loopback.io/doc/en/lb2/Error-object.html).
+   * @param {Object} models Model instances or null.
+   */
+  static createAll(
     data: PersistedData[],
     options?: Options,
     callback?: Callback<PersistedModel[]>,


### PR DESCRIPTION
Signed-off-by: Samarpan Bhattacharya <this.is.samy@gmail.com>

Adds new createAll method to support insert multiple rows in single query in memory connector
Enables multiInsertSupport in memory connector
Adds capability to createAll in dao.js for models to do multiple insert in one query via the supported connectors

Fixes https://github.com/loopbackio/loopback-connector/issues/227
See also https://github.com/loopbackio/loopback-next/issues/3357

## Checklist

- [x] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
