### PR TITLE
fix: add missing property in model generated

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -1666,11 +1666,12 @@ DataSource.prototype.discoverSchemas = function(tableName, options, cb) {
       const propName = nameMapper('column', item.columnName);
       schema.properties[propName] = {
         type: item.type,
-        required: (item.nullable === 'N' || item.nullable === 'NO' ||
+        required: !item.generated && (item.nullable === 'N' || item.nullable === 'NO' ||
           item.nullable === 0 || item.nullable === false),
         length: item.dataLength,
         precision: item.dataPrecision,
         scale: item.dataScale,
+        generated: item.generated,
       };
 
       if (pks[item.columnName]) {
@@ -1683,6 +1684,7 @@ DataSource.prototype.discoverSchemas = function(tableName, options, cb) {
         dataPrecision: item.dataPrecision,
         dataScale: item.dataScale,
         nullable: item.nullable,
+        generated: item.generated,
       };
       // merge connector-specific properties
       if (item[dbType]) {
@@ -1830,10 +1832,11 @@ DataSource.prototype.discoverSchemasSync = function(modelName, options) {
     const propName = nameMapper('column', item.columnName);
     schema.properties[propName] = {
       type: item.type,
-      required: (item.nullable === 'N'),
+      required: !item.generated && item.nullable === 'N',
       length: item.dataLength,
       precision: item.dataPrecision,
       scale: item.dataScale,
+      generated: item.generated,
     };
 
     if (pks[item.columnName]) {
@@ -1846,6 +1849,7 @@ DataSource.prototype.discoverSchemasSync = function(modelName, options) {
       dataPrecision: item.dataPrecision,
       dataScale: item.dataScale,
       nullable: i.nullable,
+      generated: i.generated,
     };
   });
 

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -34,6 +34,7 @@ describe('Memory connector with mocked discovery', function() {
       dataPrecision: null,
       dataScale: null,
       nullable: 0,
+      generated: true,
     },
     {
       owner: 'STRONGLOOP',
@@ -44,6 +45,7 @@ describe('Memory connector with mocked discovery', function() {
       dataPrecision: null,
       dataScale: null,
       nullable: 0,
+      generated: undefined,
     },
     {
       owner: 'STRONGLOOP',
@@ -54,6 +56,7 @@ describe('Memory connector with mocked discovery', function() {
       dataPrecision: 10,
       dataScale: 0,
       nullable: 1,
+      generated: undefined,
     },
     {
       owner: 'STRONGLOOP',
@@ -64,6 +67,7 @@ describe('Memory connector with mocked discovery', function() {
       dataPrecision: 10,
       dataScale: 0,
       nullable: 1,
+      generated: undefined,
     }];
 
     ds.discoverModelProperties = function(modelName, options, cb) {
@@ -214,11 +218,13 @@ describe('Memory connector with mocked discovery', function() {
               dataScale: 0,
               dataType: 'int',
               nullable: 1,
+              generated: undefined,
             },
             precision: 10,
             required: false,
             scale: 0,
             type: undefined,
+            generated: undefined,
           },
           locationId: {
             length: 20,
@@ -229,11 +235,13 @@ describe('Memory connector with mocked discovery', function() {
               dataScale: null,
               dataType: 'varchar',
               nullable: 0,
+              generated: undefined,
             },
             precision: null,
             required: true,
             scale: null,
             type: undefined,
+            generated: undefined,
           },
           productId: {
             length: 20,
@@ -244,11 +252,13 @@ describe('Memory connector with mocked discovery', function() {
               dataScale: null,
               dataType: 'varchar',
               nullable: 0,
+              generated: true,
             },
             precision: null,
-            required: true,
+            required: false,
             scale: null,
             type: undefined,
+            generated: true,
           },
           total: {
             length: null,
@@ -259,11 +269,13 @@ describe('Memory connector with mocked discovery', function() {
               dataScale: 0,
               dataType: 'int',
               nullable: 1,
+              generated: undefined,
             },
             precision: 10,
             required: false,
             scale: 0,
             type: undefined,
+            generated: undefined,
           },
         },
       };
@@ -381,6 +393,7 @@ describe('discoverModelProperties', function() {
       dataPrecision: null,
       dataScale: null,
       nullable: 0,
+      generated: undefined,
     },
     {
       owner: 'STRONGLOOP',
@@ -391,6 +404,7 @@ describe('discoverModelProperties', function() {
       dataPrecision: null,
       dataScale: null,
       nullable: 0,
+      generated: undefined,
     },
     {
       owner: 'STRONGLOOP',


### PR DESCRIPTION
Signed-off-by: Muhammad Aaqil <aaqilniz@yahoo.com>

This PR adds a missing property `generated` to the model. The issue is happening while using lb4 to discover models. Discovering a model that has a constraint of auto_increment set to true doesn't work correctly. The discovery fails to pick up the auto_increment constraint. This was happening due to the fact that `loopback-datasource-juggler` was not attaching the property to the model properties being passed to the discover generator. This PR fixes that and attaches `generated: true/false` to the model. And sets `required` to `false` if a field has `generated` set to `true`.

Fixes #899

## Checklist

- [x] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
