### PR TITLE
fix: return correct model instance in createAll

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -598,39 +598,54 @@ DataAccessObject.createAll = function(dataArray, options, cb) {
       valMap.set(obj, applyDefaultsOnWrites(val, Model.definition));
     });
 
+    const _idName = idName(Model);
+
     function createCallback(err, savedArray) {
       if (err) {
         return cb(err, objArray);
       }
-
-      const context = values.map((val) => {
+      const contextArr = savedArray.map((obj, i) => {
         return {
           Model: Model,
-          data: val,
+          data: obj,
           isNewInstance: true,
-          hookState: {},
-          options: options,
+          hookState: context[i].hookState,
+          options: context[i].options,
         };
       });
-      Model.notifyObserversOf('loaded', context, function(err) {
+      Model.notifyObserversOf('loaded', contextArr, function(err) {
         if (err) return cb(err);
 
         const afterSavePromises = [];
-        savedArray.map((obj) => {
-          const dataModel = new Model(obj);
+        savedArray.map((obj, i) => {
+          const dataModel = context[i].currentInstance;
+          const id = obj[_idName];
+          if (id) {
+            dataModel.__data[_idName] = id;
+            defineReadonlyProp(dataModel, _idName, id);
+          }
+          dataModel.__persisted = true;
+
+          // By default, the instance passed to create callback is NOT updated
+          // with the changes made through persist/loaded hooks. To preserve
+          // backwards compatibility, we introduced a new setting updateOnLoad,
+          // which if set, will apply these changes to the model instance too.
+          if (Model.settings.updateOnLoad) {
+            dataModel.setAttributes(obj);
+          }
+
+          const contxt = {
+            Model: Model,
+            instance: dataModel,
+            isNewInstance: true,
+            hookState: context[i].hookState,
+            options: context[i].options,
+          };
 
           let afterSavePromise;
           if (options.notify !== false) {
-            const context = {
-              Model: Model,
-              instance: dataModel,
-              isNewInstance: true,
-              hookState: {},
-              options: options,
-            };
-
             afterSavePromise = new Promise((resolve, reject) => {
-              Model.notifyObserversOf('after save', context, function(err) {
+              Model.notifyObserversOf('after save', contxt, function(err) {
                 if (err) {
                   reject(err);
                 } else {
@@ -644,11 +659,13 @@ DataAccessObject.createAll = function(dataArray, options, cb) {
           }
         });
 
-        Promise.all(afterSavePromises).then(saved => {
-          cb(null, saved);
-        }).catch(err => {
-          cb(err, objArray);
-        });
+        Promise.all(afterSavePromises)
+          .then((saved) => {
+            cb(null, saved);
+          })
+          .catch((err) => {
+            cb(err, objArray);
+          });
       });
     }
 

--- a/test/common_test.js
+++ b/test/common_test.js
@@ -235,38 +235,43 @@ function testOrm(dataSource) {
       title2 = 'Hello world',
       date = new Date();
 
-    Post.createAll(
-      [{
-        title: title,
+    Post.createAll([
+      {
+        title,
+        date,
+      },
+      {
+        title: 'Title 2',
         date: date,
-      }],
-      function(err, objs) {
-        const obj = objs[0];
-        test.ok(obj.id, 'Object id should present');
-        test.equals(obj.title, title);
-        // test.equals(obj.date, date);
-        obj.title = title2;
-        test.ok(obj.propertyChanged('title'), 'Title changed');
-        obj.save(function(err, obj) {
-          test.equal(obj.title, title2);
-          test.ok(!obj.propertyChanged('title'));
+      },
+    ], function(err, objs) {
+      const obj = objs[0];
+      test.ok(obj.id, 'Object id should present');
+      test.ok(objs[1].id, 'Object id should present');
+      test.equals(obj.title, title);
+      test.equals(objs[1].title, 'Title 2');
+      // test.equals(obj.date, date);
+      obj.title = title2;
+      test.ok(obj.propertyChanged('title'), 'Title changed');
+      obj.save(function(err, obj) {
+        test.equal(obj.title, title2);
+        test.ok(!obj.propertyChanged('title'));
 
-          const p = new Post({title: 1});
-          p.title = 2;
-          p.save(function(err, obj) {
+        const p = new Post({title: 1});
+        p.title = 2;
+        p.save(function(err, obj) {
+          test.ok(!p.propertyChanged('title'));
+          p.title = 3;
+          test.ok(p.propertyChanged('title'));
+          test.equal(p.title_was, 2);
+          p.save(function() {
+            test.equal(p.title_was, 3);
             test.ok(!p.propertyChanged('title'));
-            p.title = 3;
-            test.ok(p.propertyChanged('title'));
-            test.equal(p.title_was, 2);
-            p.save(function() {
-              test.equal(p.title_was, 3);
-              test.ok(!p.propertyChanged('title'));
-              test.done();
-            });
+            test.done();
           });
         });
-      },
-    );
+      });
+    });
   });
 
   it('should create object with initial data', function(test) {

--- a/test/datatype.test.js
+++ b/test/datatype.test.js
@@ -200,6 +200,32 @@ describe('datatypes', function() {
     found.nestedClass.should.have.property('roleName', 'admin');
   });
 
+  it('should create nested object defined by a class using createAll', async () => {
+    const d = new Date('2015-01-01T12:00:00');
+    let id;
+    const [created] = await Model.createAll([
+      {
+        date: d,
+        list: ['test'],
+        arr: [1, 'str'],
+        nestedClass: new NestedClass('admin'),
+      },
+    ]);
+    created.list.toJSON().should.deepEqual(['test']);
+    created.arr.toJSON().should.deepEqual([1, 'str']);
+    created.date.should.be.an.instanceOf(Date);
+    created.date.toString().should.equal(d.toString(), 'Time must match');
+    created.nestedClass.should.have.property('roleName', 'admin');
+
+    const found = await Model.findById(created.id);
+    should.exist(found);
+    found.list.toJSON().should.deepEqual(['test']);
+    found.arr.toJSON().should.deepEqual([1, 'str']);
+    found.date.should.be.an.instanceOf(Date);
+    found.date.toString().should.equal(d.toString(), 'Time must match');
+    found.nestedClass.should.have.property('roleName', 'admin');
+  });
+
   it('should respect data types when updating attributes', function(done) {
     const d = new Date;
     let id;


### PR DESCRIPTION
Signed-off-by: Samarpan Bhattacharya <this.is.samy@gmail.com>

The retuning model from createAll was not correct. It was not returning the serialized instance. Now rectified it and made it similar to create() function.

Fixes https://github.com/loopbackio/loopback-connector-postgresql/issues/530


## Checklist

- [x] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
