### PR TITLE
Fix/nullable property

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -1668,12 +1668,13 @@ DataSource.prototype.discoverSchemas = function(tableName, options, cb) {
         type: item.type,
         required: !item.generated && (item.nullable === 'N' || item.nullable === 'NO' ||
           item.nullable === 0 || item.nullable === false),
+        jsonSchema: {nullable: item.nullable === 'Y' || item.nullable === 'YES' ||
+          item.nullable === 1 || item.nullable === true},
         length: item.dataLength,
         precision: item.dataPrecision,
         scale: item.dataScale,
         generated: item.generated,
       };
-
       if (pks[item.columnName]) {
         schema.properties[propName].id = pks[item.columnName];
       }

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -90,6 +90,19 @@ describe('Memory connector with mocked discovery', function() {
     });
   });
 
+  it('should have jsonSchema: {nullable: true} in property for `available`', function(done) {
+    ds.discoverSchemas('INVENTORY', {}, function(err, schemas) {
+      if (err) return done(err);
+      schemas.should.have.property('STRONGLOOP.INVENTORY');
+      const s = schemas['STRONGLOOP.INVENTORY'];
+      s.name.should.be.eql('Inventory');
+      s.properties.available.should.have.property('jsonSchema');
+      s.properties.available.jsonSchema.should.have.property('nullable');
+      s.properties.available.jsonSchema.nullable.should.be.eql(true);
+      done();
+    });
+  });
+
   it('should keep the column names the same as database', function(done) {
     ds.discoverSchemas('INVENTORY', {disableCamelCase: true}, function(err, schemas) {
       if (err) return done(err);
@@ -211,6 +224,9 @@ describe('Memory connector with mocked discovery', function() {
         properties: {
           available: {
             length: null,
+            jsonSchema: {
+              nullable: true,
+            },
             memory: {
               columnName: 'AVAILABLE',
               dataLength: null,
@@ -228,6 +244,9 @@ describe('Memory connector with mocked discovery', function() {
           },
           locationId: {
             length: 20,
+            jsonSchema: {
+              nullable: false,
+            },
             memory: {
               columnName: 'LOCATION_ID',
               dataLength: 20,
@@ -245,6 +264,9 @@ describe('Memory connector with mocked discovery', function() {
           },
           productId: {
             length: 20,
+            jsonSchema: {
+              nullable: false,
+            },
             memory: {
               columnName: 'PRODUCT_ID',
               dataLength: 20,
@@ -262,6 +284,9 @@ describe('Memory connector with mocked discovery', function() {
           },
           total: {
             length: null,
+            jsonSchema: {
+              nullable: true,
+            },
             memory: {
               columnName: 'TOTAL',
               dataLength: null,


### PR DESCRIPTION
Patching an instance with a property set to null fails even though it is nullable in the database. [Adding](https://github.com/loopbackio/loopback-next/issues/2220#issuecomment-575933237)  `jsonSchema: {nullable: true}` in the property fixes the issue.

This PR allows `lb4 discover` to add `jsonSchema: {nullable: true}` in case the nullable is true.

## Checklist

- [x] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
