### PR TITLE
fix(ci): fix GH actions versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,13 +70,13 @@ jobs:
     name: Code Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
+      - name: Use Node.js 18
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 18
       - name: Update NPM
         run: npm install --global npm
       - name: Bootstrap project
@@ -91,13 +91,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
+      - name: Use Node.js 18
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 16
+          node-version: 18
       - name: Update NPM
         run: npm install --global npm
       - name: Bootstrap project


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Currently, commit linter and code linter were broken because of the mismatch on the npm/node.js versions. I'm using the [github workflow file](https://github.com/loopbackio/loopback-next/blob/master/.github/workflows/continuous-integration.yml#L90-L91) in loopback-next as the reference. It seems like fixing the version of `actions/checkout` and `actions/setup-node` would fix the issue. 


## Checklist

- [x] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
