### PR TITLE
fix: add error handling in case of unvailable cache server

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -499,7 +499,15 @@ DataSource.prototype.setup = function(dsName, settings) {
           debug('Connection fails: %s\nIt will be retried for the next request.', err);
         } else {
           g.error('Connection fails: %s\nIt will be retried for the next request.', err);
-          this.emit('error', err);
+          if (settings.catchFailure) {
+            try {
+              this.emit('error', err);
+            } catch (error) {
+              console.log(error);
+            }
+          } else {
+            this.emit('error', err);
+          }
         }
       } else {
         // Either lazyConnect or connector initialize() defers the connection


### PR DESCRIPTION
In case of an unavailable datasource server (like the Redis server), the app crashes.

With this PR, the users can add an option in the datasource config named `catchFailure` and set its value to true. This would prevent the app from crashing and show the connection failure error in the console.

## Checklist

- [x] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
