### PR TITLE
docs: update EOL date

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This module adopts the [Module Long Term Support (LTS)](http://github.com/CloudN
 
 | Version    | Status          | Published | EOL                  |
 | ---------- | --------------- | --------- | -------------------- |
-| 4.x        | Current         | Oct 2018  | Apr 2023 _(minimum)_ |
+| 5.x        | Current         | Sep 2023  | Apr 2026 _(minimum)_ |
+| 4.x        | Active          | Oct 2018  | Apr 2025             |
 | 3.x        | End-of-Life     | Dec 2016  | Dec 2020             |
 | 2.x        | End-of-Life     | Jul 2014  | Apr 2019             |
 


### PR DESCRIPTION
According to the LTS schedule for Node.js https://github.com/nodejs/Release, the EOL date for Node.js 20 is 2026-04-30. So we're updating the EOL date for this module accordingly. 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
