### PR TITLE
fix: set generated: false if the connector doesnot return it

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -1671,7 +1671,7 @@ DataSource.prototype.discoverSchemas = function(tableName, options, cb) {
         length: item.dataLength,
         precision: item.dataPrecision,
         scale: item.dataScale,
-        generated: item.generated,
+        generated: item.generated || false,
       };
 
       if (pks[item.columnName]) {
@@ -1684,7 +1684,7 @@ DataSource.prototype.discoverSchemas = function(tableName, options, cb) {
         dataPrecision: item.dataPrecision,
         dataScale: item.dataScale,
         nullable: item.nullable,
-        generated: item.generated,
+        generated: item.generated || false,
       };
       // merge connector-specific properties
       if (item[dbType]) {
@@ -1836,7 +1836,7 @@ DataSource.prototype.discoverSchemasSync = function(modelName, options) {
       length: item.dataLength,
       precision: item.dataPrecision,
       scale: item.dataScale,
-      generated: item.generated,
+      generated: item.generated || false,
     };
 
     if (pks[item.columnName]) {
@@ -1849,7 +1849,7 @@ DataSource.prototype.discoverSchemasSync = function(modelName, options) {
       dataPrecision: item.dataPrecision,
       dataScale: item.dataScale,
       nullable: i.nullable,
-      generated: i.generated,
+      generated: i.generated || false,
     };
   });
 

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -45,7 +45,7 @@ describe('Memory connector with mocked discovery', function() {
       dataPrecision: null,
       dataScale: null,
       nullable: 0,
-      generated: undefined,
+      generated: false,
     },
     {
       owner: 'STRONGLOOP',
@@ -56,7 +56,7 @@ describe('Memory connector with mocked discovery', function() {
       dataPrecision: 10,
       dataScale: 0,
       nullable: 1,
-      generated: undefined,
+      generated: false,
     },
     {
       owner: 'STRONGLOOP',
@@ -67,7 +67,7 @@ describe('Memory connector with mocked discovery', function() {
       dataPrecision: 10,
       dataScale: 0,
       nullable: 1,
-      generated: undefined,
+      generated: false,
     }];
 
     ds.discoverModelProperties = function(modelName, options, cb) {
@@ -218,13 +218,13 @@ describe('Memory connector with mocked discovery', function() {
               dataScale: 0,
               dataType: 'int',
               nullable: 1,
-              generated: undefined,
+              generated: false,
             },
             precision: 10,
             required: false,
             scale: 0,
             type: undefined,
-            generated: undefined,
+            generated: false,
           },
           locationId: {
             length: 20,
@@ -235,13 +235,13 @@ describe('Memory connector with mocked discovery', function() {
               dataScale: null,
               dataType: 'varchar',
               nullable: 0,
-              generated: undefined,
+              generated: false,
             },
             precision: null,
             required: true,
             scale: null,
             type: undefined,
-            generated: undefined,
+            generated: false,
           },
           productId: {
             length: 20,
@@ -269,13 +269,13 @@ describe('Memory connector with mocked discovery', function() {
               dataScale: 0,
               dataType: 'int',
               nullable: 1,
-              generated: undefined,
+              generated: false,
             },
             precision: 10,
             required: false,
             scale: 0,
             type: undefined,
-            generated: undefined,
+            generated: false,
           },
         },
       };
@@ -393,7 +393,7 @@ describe('discoverModelProperties', function() {
       dataPrecision: null,
       dataScale: null,
       nullable: 0,
-      generated: undefined,
+      generated: false,
     },
     {
       owner: 'STRONGLOOP',
@@ -404,7 +404,7 @@ describe('discoverModelProperties', function() {
       dataPrecision: null,
       dataScale: null,
       nullable: 0,
-      generated: undefined,
+      generated: false,
     },
     {
       owner: 'STRONGLOOP',


### PR DESCRIPTION
Fixes #[9897](https://github.com/loopbackio/loopback-next/issues/9897)

## Checklist

- [x] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
