### PR TITLE
fix: set useDefaultIdType while discovering models

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -1733,6 +1733,14 @@ DataSource.prototype.discoverSchemas = function(tableName, options, cb) {
       if (uniqueKeys.includes(propName)) {
         schema.properties[propName]['index'] = {unique: true};
       }
+      // set useDefaultIdType: false in the case of id property with generated: 1 and has string type
+      if (
+        schema.properties[propName]['id'] &&
+        schema.properties[propName]['generated'] &&
+        schema.properties[propName]['type'].toLowerCase() === 'string'
+      ) {
+        schema.properties[propName]['useDefaultIdType'] = false;
+      }
       const dbSpecific = schema.properties[propName][dbType] = {
         columnName: item.columnName,
         dataType: item.dataType,


### PR DESCRIPTION
The juggler changes the type of the id to the default type from the connector except useDefaultIdType is set to false.
This PR enables the discoverer to add this flag when the `type` is available in the property.

## Checklist

- [x] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
